### PR TITLE
allow keybind to be turned off

### DIFF
--- a/lua/telescope-colorscheme-persist/config.lua
+++ b/lua/telescope-colorscheme-persist/config.lua
@@ -9,7 +9,7 @@ local M = {
 function M.setup(opts)
   opts = opts or {}
   for k, v in pairs(opts) do
-    if type(M[k]) == type(v) then
+    if type(M[k]) == type(v) or (k == 'keybind' and v == false) then
       M[k] = v
     else
       vim.notify("Invalid option type for " .. k, vim.log.levels.WARN)

--- a/lua/telescope-colorscheme-persist/init.lua
+++ b/lua/telescope-colorscheme-persist/init.lua
@@ -85,7 +85,9 @@ function M.setup(opts)
   if M.current ~= vim.g.colors_name then
     M.apply_colorscheme(M.current)
   end
-  vim.keymap.set("n", config.keybind, M.picker, { desc = "Open colorscheme picker" })
+  if config.keybind then
+    vim.keymap.set("n", config.keybind, M.picker, { desc = "Open colorscheme picker" })
+  end
 end
 
 return M


### PR DESCRIPTION
Hey so I noticed that this plugin was interfering with lazy loading of colorschemes using lazy.nvim since it directly sets the keybind by default. This is just a little PR to be able to optionally turn off the automatic keybind setter by setting `keybind = false` in options. I can either add to this PR or spin up another later with some documentation on how to get lazy loading of colorschemes in lazy.nvim working with this plugin, but this is the minimum change needed in the plugin code to get it to work.